### PR TITLE
Remove the need for ghostscript

### DIFF
--- a/python/004_pdf_composition/README.md
+++ b/python/004_pdf_composition/README.md
@@ -1,12 +1,10 @@
 Example 4: PDF Compositing
 ==========================
 
-The example covers the use case of having pre-existing stationary,
-and wanting to render handwriting on top of it for printing.
+The example covers the use case of having pre-existing stationary, and wanting
+to render handwriting on top of it for printing.
 
-This example requires 2 PDF libraries to work
-  - `pdfrw` installed via pip, this allows writing new PDFs
-  - `ghostscript` is used to reformat renders and move them.
+This example requires the `pdfrw` libraries to work. Install this via pip.
 
 We start with a run of the mill template, a 5x7" card with a company logo
 
@@ -18,14 +16,10 @@ Run our script, then you end up with something like this
 
 
 To run this example:
-  - Make a new virtualenv (optional)
-  - Activate the virtualenv (optional)
-  - install python dependencies with `pip install -r requirements.txt`
-  - install ghostscript (http://ghostscript.com/download/gsdnld.html)
-  this can easily be installed via homebrew on OSX or most package
-  managers on Linux distros
-  - edit the `render_and_compose.py` script to change variables
+- Make a new virtualenv (optional)
+- Activate the virtualenv (optional)
+- Install python dependencies with `pip install -r requirements.txt`
+- Edit the `render_and_compose.py` script to change variables
   (your API credentials, handwriting style, size, color, etc...)
-  - run `python ./render_and_compose.py`
-  - open out.png
-
+- Run `python ./render_and_compose.py`
+- Open `out.png`

--- a/python/004_pdf_composition/README.md
+++ b/python/004_pdf_composition/README.md
@@ -4,7 +4,8 @@ Example 4: PDF Compositing
 The example covers the use case of having pre-existing stationary, and wanting
 to render handwriting on top of it for printing.
 
-This example requires the `pdfrw` libraries to work. Install this via pip.
+This example requires the `pdfrw` and `requests` libraries to work. Install
+these via pip.
 
 We start with a run of the mill template, a 5x7" card with a company logo
 

--- a/python/004_pdf_composition/render_and_compose.py
+++ b/python/004_pdf_composition/render_and_compose.py
@@ -52,69 +52,22 @@ def render_handwritten_msg(hw_id, msg):
   return render_api(params)
 
 
-def move_pdf(original, width, height, offset_x, offset_y):
-  """Moves a pdf by creating a new PDF of dimensions `width` and `height`,
-  then moving `original` to a new offset_x, offset_y both of which should
-  be passed as integers in points.
-
-  NOTE: the Y-axis grows from bottom to top, not top to bottom.
-  The X-axis grows from left to right.
-
-  original (string) original PDF data
-  width (int) width of new PDF in points
-  heigh (int) height of new PDF in points
-  offset_x (int) how far to move the existing PDF on the X-axis
-    in relation to the new file's origin (bottom-left)
-  offset_y (int) how far to move the existing PDF on the Y-axis
-    in relation to the new file's origin (bottom-left)
-
-  Example:
-    You have a file `render.pdf` that is 3inches tall by 5inches wide. You want
-    to end up with the same image but centered on a 5x7in card. You would call
-    this function like so:
-
-    with open('render.pdf', 'rb') as f:
-      pdf_data = f.read()
-    moved = move_pdf(pdf_data, 7*72, 5*72, 72, 72)
-    with open('moved.pdf', 'wb') as f:
-      f.write(moved)
-
-    `moved.pdf` would now contain the 5x7in card.
-  """
-  cmd = ["gs", "-q", "-sDEVICE=pdfwrite",
-      "-sOutputFile=-",
-      "-dBATCH", "-dNOPAUSE", "-dFIXEDMEDIA",
-      "-dDEVICEWIDTHPOINTS=%s" % width,
-      "-dDEVICEHEIGHTPOINTS=%s" % height,
-      "-c",
-      "<</PageOffset [%s %s]>>setpagedevice" % (offset_x, offset_y),
-      "-"]
-  p = Popen(cmd, stdin=PIPE, stderr=PIPE, stdout=PIPE)
-  out, err = p.communicate(original)
-
-  if p.returncode != 0:
-    print 'Error calling ghostscript:'
-    print err
-
-  return out
-
-
 def make_card():
-  """Render a message via the API, recenter the rendered message, then composite
-  the render on top of an existing template
+  """Render a message via the API, then composite the render on top of an
+  existing template, at the correct position.
   """
   # render the message
-  unmoved_render = render_handwritten_msg(HANDWRITING_ID, MESSAGE_TO_RENDER)
-  # move the render to the right spot on the card
-  moved_render = move_pdf(unmoved_render, CARD_W_POINTS, CARD_H_POINTS,
-    OFFSET_X_POINTS, OFFSET_Y_POINTS)
+  message_render = render_handwritten_msg(HANDWRITING_ID, MESSAGE_TO_RENDER)
 
   # wrap the render and the template files with pdfrw
   template_pdf = PdfReader('template.pdf')
-  render_pdf = PdfReader(fdata=moved_render)
+  message_pdf = PdfReader(fdata=message_render)
 
   # set up our render as a "stamp" to put on the template
-  stamp = PageMerge().add(render_pdf.pages[0])[0]
+  stamp = PageMerge().add(message_pdf.pages[0])[0]
+  # move the render to the right spot on the card (offset is from bottom left)
+  stamp.x = OFFSET_X_POINTS
+  stamp.y = OFFSET_Y_POINTS
   pm = PageMerge(template_pdf.pages[0])
   pm.add(stamp)
   pm.render()

--- a/python/004_pdf_composition/render_and_compose.py
+++ b/python/004_pdf_composition/render_and_compose.py
@@ -65,9 +65,10 @@ def make_card():
 
   # set up our render as a "stamp" to put on the template
   stamp = PageMerge().add(message_pdf.pages[0])[0]
-  # move the render to the right spot on the card (offset is from bottom left)
+  # x is the distance from the left edge of the template to the left edge of the stamp:
   stamp.x = OFFSET_X_POINTS
-  stamp.y = OFFSET_Y_POINTS
+  # y is the distance from the bottom edge of the template to the top edge of the stamp:
+  stamp.y = CARD_H_POINTS - OFFSET_Y_POINTS
   pm = PageMerge(template_pdf.pages[0])
   pm.add(stamp)
   pm.render()


### PR DESCRIPTION
This depends on the fix in https://github.com/handwritingio/render/pull/139. It would probably still be good to include the ghostscript code in a separate example (maybe a shell-only example). As long as someone has pdfrw available, though, they might as well use it to its fullest.